### PR TITLE
Set explicit subscription_id on root azurerm provider to fix planning error

### DIFF
--- a/platform-landing-zone.auto.tfvars
+++ b/platform-landing-zone.auto.tfvars
@@ -51,7 +51,7 @@ custom_replacements = {
     primary_virtual_network_gateway_vpn_enabled           = false
     primary_private_dns_zones_enabled                     = true
     primary_private_dns_auto_registration_zone_enabled    = true
-    primary_private_dns_resolver_enabled                  = true
+    primary_private_dns_resolver_enabled                  = false
     primary_bastion_enabled                               = false
 
     # Resource names primary connectivity

--- a/terraform.tf
+++ b/terraform.tf
@@ -37,6 +37,7 @@ provider "azapi" {
 
 provider "azurerm" {
   resource_provider_registrations = "none"
+  subscription_id = var.subscription_id_management
   features {
     resource_group {
       prevent_deletion_if_contains_resources = false

--- a/terraform.tf
+++ b/terraform.tf
@@ -37,7 +37,7 @@ provider "azapi" {
 
 provider "azurerm" {
   resource_provider_registrations = "none"
-  subscription_id = var.subscription_id_management
+  subscription_id                 = var.subscription_id_management
   features {
     resource_group {
       prevent_deletion_if_contains_resources = false


### PR DESCRIPTION
Add subscription_id = var.subscription_id_management to root azurerm provider. Fixes error: 'subscription ID could not be determined and was not specified'.