### PR TITLE
policy: remove Deny-IP-forwarding override from landingzones

### DIFF
--- a/platform-landing-zone.auto.tfvars
+++ b/platform-landing-zone.auto.tfvars
@@ -212,13 +212,6 @@ management_group_settings = {
         }
       }
     }
-    landingzones = {
-      policy_assignments = {
-        Deny-IP-forwarding = {
-          enforcement_mode = "DoNotEnforce"
-        }
-      }
-    }
   }
   /*
   ## Example of how to add management group role assignments

--- a/terraform.tf
+++ b/terraform.tf
@@ -37,7 +37,7 @@ provider "azapi" {
 
 provider "azurerm" {
   resource_provider_registrations = "none"
-  subscription_id = var.subscription_id_management
+  subscription_id                 = var.subscription_id_management
   features {
     resource_group {
       prevent_deletion_if_contains_resources = false


### PR DESCRIPTION
Remove the policy override for Deny-IP-forwarding in platform-landing-zone.auto.tfvars (management_group_settings.policy_assignments_to_modify.landingzones). This stops suppressing enforcement and lets default ALZ behavior apply.